### PR TITLE
Fix handling of MediaSource.readyState values

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 // Place your settings in this file to overwrite default and user settings.
 {
+    "editor.tabSize": 2,
+    "editor.insertSpaces": true
 }

--- a/dist/amd/StreamController.d.ts
+++ b/dist/amd/StreamController.d.ts
@@ -90,4 +90,5 @@ export default class StreamController {
     private _onPauseStateChange();
     private _onVideoEnded();
     private _onVideoRateChange();
+    private _isMediaSourceReadyState(value, state);
 }

--- a/dist/amd/StreamController.js
+++ b/dist/amd/StreamController.js
@@ -3,9 +3,13 @@ define(["require", "exports", './EventGroup', './Async', './Stream', './MetricSe
     var PERMITTED_GAP_SECONDS_BETWEEN_RANGES = 0.06;
     // When we try to calculate which fragment a "currentTime" value aligns on, we subtract this value from currentTime first.
     var SEEK_TIME_BUFFER_SECONDS = 0.5;
-    var MEDIASOURCE_READYSTATE_CLOSED = 0;
-    var MEDIASOURCE_READYSTATE_OPEN = 1;
-    var MEDIASOURCE_READYSTATE_ENDED = 2;
+    var MediaSourceReadyState;
+    (function (MediaSourceReadyState) {
+        // The string values are used by IE instead of the numeric values.
+        MediaSourceReadyState[MediaSourceReadyState["closed"] = 0] = "closed";
+        MediaSourceReadyState[MediaSourceReadyState["open"] = 1] = "open";
+        MediaSourceReadyState[MediaSourceReadyState["ended"] = 2] = "ended";
+    })(MediaSourceReadyState || (MediaSourceReadyState = {}));
     var StreamController = (function () {
         function StreamController(videoElement, mediaSource, settings) {
             this._events = new EventGroup_1.default(this);
@@ -233,7 +237,7 @@ define(["require", "exports", './EventGroup', './Async', './Stream', './MetricSe
             var streamIndex;
             if (!_this._isDisposed) {
                 var currentTime = _this._settings.startTime || _this._videoElement.currentTime;
-                if (streams && streams.length && _this._mediaSource && _this._mediaSource.readyState !== MEDIASOURCE_READYSTATE_CLOSED) {
+                if (streams && streams.length && _this._mediaSource && !_this._isMediaSourceReadyState(_this._mediaSource.readyState, MediaSourceReadyState.closed)) {
                     var streamsAppendable = true;
                     while (_this._appendIndex < streams[0].fragments.length) {
                         // Try to append the current index.
@@ -280,7 +284,7 @@ define(["require", "exports", './EventGroup', './Async', './Stream', './MetricSe
                             break;
                         }
                     }
-                    if (_this._appendIndex == streams[0].fragments.length && _this._mediaSource.readyState === MEDIASOURCE_READYSTATE_OPEN) {
+                    if (_this._appendIndex == streams[0].fragments.length && _this._isMediaSourceReadyState(_this._mediaSource.readyState, MediaSourceReadyState.open)) {
                         _this._mediaSource.endOfStream();
                     }
                     _this._loadNextFragment();
@@ -535,6 +539,9 @@ define(["require", "exports", './EventGroup', './Async', './Stream', './MetricSe
             if (this._videoElement.playbackRate != expectedRate) {
                 this._videoElement.playbackRate = this._videoElement.defaultPlaybackRate = expectedRate;
             }
+        };
+        StreamController.prototype._isMediaSourceReadyState = function (value, state) {
+            return value === state || value === MediaSourceReadyState[state];
         };
         return StreamController;
     })();

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -57,6 +57,7 @@ gulp.task('jshint', function() {
 gulp.task('typescript', ['clean'], function(cb) {
     var tsResult = gulp.src('src/*.ts')
         .pipe(ts({
+            typescript: require('typescript'),
             module: 'amd',
             declaration: true,
             target: 'ES5'

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "karma-phantomjs-launcher": "0.1.2",
     "karma-qunit": "^0.1.1",
     "merge2": "^0.3.6",
+    "typescript": "~1.5.0",
     "phantomjs": "^1.9.7-3",
     "qunitjs": "~1.14.0",
     "vinyl-buffer": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashling",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "homepage": "http://dzearing.github.io/dashling",
   "author": {
     "name": "David Zearing",

--- a/src/StreamController.ts
+++ b/src/StreamController.ts
@@ -18,9 +18,12 @@ const PERMITTED_GAP_SECONDS_BETWEEN_RANGES = 0.06;
 // When we try to calculate which fragment a "currentTime" value aligns on, we subtract this value from currentTime first.
 const SEEK_TIME_BUFFER_SECONDS = 0.5;
 
-const MEDIASOURCE_READYSTATE_CLOSED = 0;
-const MEDIASOURCE_READYSTATE_OPEN = 1;
-const MEDIASOURCE_READYSTATE_ENDED = 2;
+enum MediaSourceReadyState {
+  // The string values are used by IE instead of the numeric values.
+  closed = 0,
+  open = 1,
+  ended = 2
+}
 
 export default class StreamController {
   public streams: Stream[];
@@ -332,7 +335,7 @@ export default class StreamController {
     if (!_this._isDisposed) {
       let currentTime = _this._settings.startTime || _this._videoElement.currentTime;
 
-      if (streams && streams.length && _this._mediaSource && _this._mediaSource.readyState !== MEDIASOURCE_READYSTATE_CLOSED) {
+      if (streams && streams.length && _this._mediaSource && !_this._isMediaSourceReadyState(_this._mediaSource.readyState, MediaSourceReadyState.closed)) {
         let streamsAppendable = true;
 
         while (_this._appendIndex < streams[0].fragments.length) {
@@ -392,7 +395,7 @@ export default class StreamController {
           }
         }
 
-        if (_this._appendIndex == streams[0].fragments.length && _this._mediaSource.readyState === MEDIASOURCE_READYSTATE_OPEN) {
+        if (_this._appendIndex == streams[0].fragments.length && _this._isMediaSourceReadyState(_this._mediaSource.readyState, MediaSourceReadyState.open)) {
           _this._mediaSource.endOfStream();
         }
 
@@ -708,6 +711,10 @@ export default class StreamController {
     if (this._videoElement.playbackRate != expectedRate) {
       this._videoElement.playbackRate = this._videoElement.defaultPlaybackRate = expectedRate;
     }
+  }
+
+  private _isMediaSourceReadyState(value: string | MediaSourceReadyState, state: MediaSourceReadyState) {
+    return value === state || value === MediaSourceReadyState[state];
   }
 }
 


### PR DESCRIPTION
Created a new `MediaSourceReadyState` enum with field names matching the values used by browsers, and numeric values matching the official standard.
Defined a new `_isMediaSourceReadyState` method on `StreamController` to compare a value of `MediaSource.readyState` with one of the enum values.
Pinned `typescript` at `1.5.0` in the package `devDependencies` to avoid breaking changes in the newer TypeScript version.
